### PR TITLE
Fix codes to works on 2019.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,19 +1,19 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "24.0.0"
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
     defaultConfig {
         applicationId "com.vansuita.checknewappversionavailable.sample"
-        minSdkVersion 9
-        targetSdkVersion 24
+        minSdkVersion 23
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:24.2.1'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
     //Add this line
-    compile project(':library')
+    implementation project(':library')
 }

--- a/app/src/main/java/com/vansuita/checknewappversionavailable/sample/MainActivity.java
+++ b/app/src/main/java/com/vansuita/checknewappversionavailable/sample/MainActivity.java
@@ -1,10 +1,10 @@
 package com.vansuita.checknewappversionavailable.sample;
 
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
 
 import com.vansuita.checknewappversionavailable.CheckNewAppVersion;
 
+import androidx.appcompat.app.AppCompatActivity;
 
 public class MainActivity extends AppCompatActivity {
 

--- a/app/src/main/java/com/vansuita/checknewappversionavailable/sample/MainActivity.java
+++ b/app/src/main/java/com/vansuita/checknewappversionavailable/sample/MainActivity.java
@@ -1,6 +1,7 @@
 package com.vansuita.checknewappversionavailable.sample;
 
 import android.os.Bundle;
+import android.util.Log;
 
 import com.vansuita.checknewappversionavailable.CheckNewAppVersion;
 
@@ -13,10 +14,9 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        new CheckNewAppVersion(this).setOnTaskCompleteListener(new CheckNewAppVersion.ITaskComplete() {
+        new CheckNewAppVersion(this, 30000, "com.harex.android.ubpay").setOnTaskCompleteListener(new CheckNewAppVersion.ITaskComplete() {
             @Override
             public void onTaskComplete(CheckNewAppVersion.Result result) {
-
                 //Checks if there is a new version available on Google Play Store.
                 result.hasNewVersion();
 
@@ -27,7 +27,11 @@ public class MainActivity extends AppCompatActivity {
                 result.getOldVersionCode();
 
                 //Opens the Google Play Store on your app page to do the update.
-                result.openUpdateLink();
+                result.openUpdateLink(MainActivity.this);
+
+                Log.d("CheckNewAppVersion", "CheckNewAppVersion Sample" +
+                    "packageVersion : " + result.getOldVersionCode() + "\n" +
+                    "googlePlayVersion : " + result.getNewVersionCode());
             }
         }).execute();
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:3.5.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -16,7 +17,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
-
+        google()
         //Add this line
         maven { url "https://jitpack.io" }
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 28 10:00:20 PST 2015
+#Mon Oct 14 17:56:50 KST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -7,12 +7,12 @@ group = 'com.github.jrvansuita'
 
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "24.0.0"
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
-        minSdkVersion 9
-        targetSdkVersion 24
+        minSdkVersion 19
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }
@@ -20,8 +20,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:24.2.1'
-    compile 'org.jsoup:jsoup:1.9.2'
+    implementation 'org.jsoup:jsoup:1.11.3'
 }
 
 // build a jar with source files

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,1 +1,5 @@
-<manifest package="com.vansuita.checknewappversionavailable"/>
+<manifest
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.vansuita.checknewappversionavailable">
+  <uses-permission android:name="android.permission.INTERNET"/>
+</manifest>

--- a/library/src/main/java/com/vansuita/checknewappversionavailable/CheckNewAppVersion.java
+++ b/library/src/main/java/com/vansuita/checknewappversionavailable/CheckNewAppVersion.java
@@ -8,57 +8,95 @@ import android.net.Uri;
 import android.os.AsyncTask;
 
 import org.jsoup.Jsoup;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import java.io.IOException;
+import java.util.StringTokenizer;
 
 /**
  * Created by jrvansuita on 17/09/15.
+ * Modified by HaenaraShin on 19/10/14.
  */
 public class CheckNewAppVersion extends AsyncTask<Void, Void, CheckNewAppVersion.Result> {
-
-    private static final String REFERRER = "http://www.google.com";
-    private static final String DIV = "div[itemprop=softwareVersion]";
+    private static final String REFERRER = "https://www.google.com";
     private static final String USER_AGENT = "Mozilla/5.0 (Windows; U; WindowsNT 5.1; en-US; rv1.8.1.6) Gecko/20070725 Firefox/2.0.0.6";
-    private static final String PLAY_STORE_LINK = "http://play.google.com/store/apps/details?id=%s&hl=en";
+    private static final String PLAY_STORE_LINK = "https://play.google.com/store/apps/details?id=%s&hl=en";
+    private static final String CSS_QUERY = ".hAyfc";
+    private static final String CURRENT_VERSION_SELECT = ".BgcNfc";
+    private static final String VESION_SELECT = ".htlgb";
+    private static final String VARIES_WITH_DEVICE = "Varies with device";
 
-    private Result result;
+    private final String PACKAGE_NAME;
+    private final int TIMEOUT;
+
     private Context context;
     private ITaskComplete listener;
 
     public CheckNewAppVersion(Context context) {
+        this(context, 30000, context.getPackageName());
+    }
+    public CheckNewAppVersion(Context context, int timeout, String packageName) {
         this.context = context;
-        this.result = new Result(context);
+        this.TIMEOUT = timeout;
+        this.PACKAGE_NAME = packageName;
     }
 
     public String getExternalAppLink() {
-        return String.format(PLAY_STORE_LINK, context.getPackageName());
+        return String.format(PLAY_STORE_LINK, PACKAGE_NAME);
     }
 
     @Override
     protected Result doInBackground(Void... params) {
+        String oldVersion = "";
+        String newVersion = "";
         try {
             //Getting the current versions of the app and setting as old version is Result object.
-            PackageInfo info = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
-            result.setOldVersionCode(info.versionName);
+            PackageInfo packageInfo = context.getPackageManager().getPackageInfo(PACKAGE_NAME, 0);
+            oldVersion = packageInfo.versionName;
         } catch (PackageManager.NameNotFoundException e) {
             //Handle this exception by your own way...
+            e.printStackTrace();
         }
 
         try {
             //Using the Jsoup library to request the store app page and getting the app version code.
-            String newVersion = Jsoup.connect(getExternalAppLink())
-                    .timeout(30000)
-                    .userAgent(USER_AGENT)
-                    .referrer(REFERRER)
-                    .get()
-                    .select(DIV)
-                    .first()
-                    .ownText();
-
-            result.setNewVersionCode(newVersion);
-        } catch (Exception e) {
+            newVersion = getNewVersionCode();
+        } catch (IOException | NullPointerException e) {
             //Handle this exception by your own way...
+            e.printStackTrace();
         }
 
-        return result;
+        return new Result(newVersion, oldVersion);
+    }
+
+    /**
+     * Using the Jsoup library to request the store app page and getting the app version code.
+     * @return
+     * @throws IOException
+     * @throws NullPointerException
+     */
+    private String getNewVersionCode() throws IOException, NullPointerException {
+        // You may get a version name easier and faster with
+        // "Jsoup.connect(getExternalAppLink()).get().select(VESION_SELECT).get(7).ownText()".
+        // but, the following code might be safer.
+        Elements elements = Jsoup.connect(getExternalAppLink())
+            .timeout(TIMEOUT)
+            .userAgent(USER_AGENT)
+            .referrer(REFERRER)
+            .get()
+            .select(CSS_QUERY);
+        for (Element element : elements) {
+            if (element.select(CURRENT_VERSION_SELECT).first().ownText().contains("Current Version")){
+                Elements elements1 = element.select(VESION_SELECT);
+                for (Element e: elements1){
+                    if (!e.ownText().trim().isEmpty()) {
+                        return e.ownText();
+                    }
+                }
+            }
+        }
+        return null;
     }
 
     @Override
@@ -78,12 +116,43 @@ public class CheckNewAppVersion extends AsyncTask<Void, Void, CheckNewAppVersion
     }
 
     public class Result {
-        private Context context;
-        private String newVersionCode;
-        private String oldVersionCode;
+        final private String newVersionCode;
+        final private String oldVersionCode;
 
         public boolean hasNewVersion() {
-            return onlyNumbers(getOldVersionCode()) < onlyNumbers(getNewVersionCode());
+            return compareVersion(oldVersionCode, newVersionCode);
+        }
+
+        /**
+         * TRUE : oldVersionCode < newVersionCode
+         * FALSE : oldVersionCode >= newVersionCode OR an error occurred.
+         * @param oldVersionCode
+         * @param newVersionCode
+         * @return
+         */
+        private boolean compareVersion(String oldVersionCode, String newVersionCode) {
+            if (newVersionCode.contains(VARIES_WITH_DEVICE)) {
+                // ignore VARIES_WITH_DEVICE
+                return false;
+            }
+            StringTokenizer serverTokenizer = new StringTokenizer(newVersionCode, ".");
+            StringTokenizer appTokenizer = new StringTokenizer(oldVersionCode, ".");
+            if (serverTokenizer.countTokens() != appTokenizer.countTokens()){
+                // version name format is not same.
+                return true;
+            }
+            while (serverTokenizer.hasMoreTokens()) { // Major, Minor, Patch, ...
+                try {
+                    long googlePlayVer = Long.valueOf(serverTokenizer.nextToken().replaceAll("\\D+", ""));
+                    long packageVer = Long.valueOf(appTokenizer.nextToken().replaceAll("\\D+", ""));
+                    if (googlePlayVer > packageVer){ // higher version has found.
+                        return true;
+                    }
+                } catch (NumberFormatException e){
+                    return false;
+                }
+            }
+            return false;
         }
 
         public String getNewVersionCode() {
@@ -94,39 +163,18 @@ public class CheckNewAppVersion extends AsyncTask<Void, Void, CheckNewAppVersion
             return oldVersionCode;
         }
 
-        public void setNewVersionCode(String newVersionCode) {
-            this.newVersionCode = newVersionCode;
-        }
-
-        public void setOldVersionCode(String oldVersionCode) {
-            this.oldVersionCode = oldVersionCode;
-        }
-
-        public Context getContext() {
-            return context;
-        }
-
+        @Deprecated
         public void openUpdateLink() {
             context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(getExternalAppLink())));
         }
 
-        public Result(Context context, String newVersionCode, String oldVersionCode) {
-            this.context = context;
+        public void openUpdateLink(Context context) {
+            context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(getExternalAppLink())));
+        }
+
+        public Result(String newVersionCode, String oldVersionCode) {
             this.newVersionCode = newVersionCode;
             this.oldVersionCode = oldVersionCode;
-        }
-
-        public Result(Context context) {
-            this(context, "", "");
-        }
-
-        public long onlyNumbers(String s) {
-            String val = s.replaceAll("\\D+", "");
-            try {
-                return Long.valueOf(val);
-            }catch (Exception e){
-                return 0;
-            }
         }
     }
 }


### PR DESCRIPTION
Fix JSoup scraper codes to works on 2019.
Migrate to gradle:3.5.0, compileSdk 28 and androidx.
Since the Google Play web page has been changed, scraper code has been changed.